### PR TITLE
withPrintFn (\_ -> return()) will now avoid writing to stdout

### DIFF
--- a/Data/SVM/Raw.hsc
+++ b/Data/SVM/Raw.hsc
@@ -16,7 +16,7 @@ module Data.SVM.Raw where
 import Foreign.Storable (Storable(..), peekByteOff, pokeByteOff)
 import Foreign.C.Types (CDouble (..), CInt (..))
 import Foreign.C.String (CString)
-import Foreign.Ptr(nullPtr, Ptr)
+import Foreign.Ptr(nullPtr, Ptr, FunPtr)
 import Foreign.ForeignPtr (FinalizerPtr)
 
 data CSvmNode = CSvmNode { 
@@ -139,3 +139,8 @@ foreign import ccall unsafe "svm.h svm_check_parameter" c_svm_check_parameter ::
 foreign import ccall unsafe "svm.h &svm_destroy_model" c_svm_destroy_model :: FinalizerPtr CSvmModel
 
 foreign import ccall unsafe "svm.h clone_model_support_vectors" c_clone_model_support_vectors :: Ptr CSvmModel -> IO CInt
+
+type CSvmPrintFn = CString -> IO ()
+
+foreign import ccall unsafe "svm.h svm_set_print_string_function" c_svm_set_print_string_function :: FunPtr CSvmPrintFn -> IO ()
+foreign import ccall unsafe "wrapper" createSvmPrintFnPtr :: CSvmPrintFn -> IO (FunPtr CSvmPrintFn)

--- a/cbits/svm.cpp
+++ b/cbits/svm.cpp
@@ -2598,7 +2598,7 @@ double svm_predict_values(const svm_model *model, const svm_node *x, double* dec
 
 double svm_predict(const svm_model *model, const svm_node *x)
 {
-	print_node(x);
+	// print_node(x);
 	int nr_class = model->nr_class;
 	double *dec_values;
 	if(model->param.svm_type == ONE_CLASS ||


### PR DESCRIPTION
Fixes #2 - prints to stdout

Made the default print function use stderr, exposed
svm_set_print_string_function in SVM.Raw, and made a withPrintFn
helper to easily pass a Haskell print function in and free the
function pointer afterwards.

Also commented out the print_node(x) call from predict completely,
looked like a debug thing since it was commented out elsewhere …