### PR TITLE
Fix inappropriate laziness in predict

### DIFF
--- a/Data/SVM.hs
+++ b/Data/SVM.hs
@@ -218,7 +218,7 @@ predict (Model modelForeignPtr) vector = action
     where action :: IO Double
           action = withForeignPtr modelForeignPtr $ \modelPtr ->
                    withCSvmNodeArray vector $ \vectorPtr ->
-                        return . realToFrac . c_svm_predict modelPtr $ vectorPtr
+                        realToFrac <$> c_svm_predict modelPtr vectorPtr
 
 -- |Wrapper to change the libsvm output reporting function.
 --

--- a/Data/SVM/Raw.hsc
+++ b/Data/SVM/Raw.hsc
@@ -128,7 +128,7 @@ foreign import ccall unsafe "svm.h svm_train" c_svm_train :: Ptr CSvmProblem -> 
                         
 foreign import ccall unsafe "svm.h svm_cross_validation" c_svm_cross_validation:: Ptr CSvmProblem -> Ptr CSvmParameter -> CInt -> Ptr CDouble -> IO () 
 
-foreign import ccall unsafe "svm.h svm_predict" c_svm_predict :: Ptr CSvmModel -> Ptr CSvmNode -> CDouble
+foreign import ccall unsafe "svm.h svm_predict" c_svm_predict :: Ptr CSvmModel -> Ptr CSvmNode -> IO CDouble
 
 foreign import ccall unsafe "svm.h svm_save_model" c_svm_save_model :: CString -> Ptr CSvmModel -> IO CInt
 


### PR DESCRIPTION
Previously `predict` would return a thunk instead of performing the
intended FFI call. This defeated the `with` calls that enclosed the call
and consequently resulted in memory unsafety.